### PR TITLE
GEM_HOST_API_KEY is enough for a gem release

### DIFF
--- a/.github/workflows/gem_release.yml
+++ b/.github/workflows/gem_release.yml
@@ -16,10 +16,6 @@ jobs:
         ruby-version: '2.7'
     - name: Publish to RubyGems
       run: |
-        mkdir -p $HOME/.gem
-        touch $HOME/.gem/credentials
-        chmod 0600 $HOME/.gem/credentials
-        printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
         rake gem
         gem push pkg/inprovise.gem
       env:


### PR DESCRIPTION
    * .github/workflows/gem_release.yml: